### PR TITLE
CI: enable GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+name: Main
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '0 0 * * 6'
+
+jobs:
+  main:
+    runs-on: ${{ matrix.environment }}
+    strategy:
+      matrix:
+        environment:
+          - macos-10.15
+          - ubuntu-20.04
+          - windows-2019
+    env:
+      DOTNET_NOLOGO: 1
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      NUGET_PACKAGES: ${{ github.workspace }}/.github/nuget-packages
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+      - name: NuGet Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.NUGET_PACKAGES }}
+          key: ${{ runner.os }}.nuget.${{ hashFiles('**/*.csproj') }}
+      - name: Build
+        run: dotnet build --configuration Release
+      - name: Test
+        run: dotnet test --configuration Release

--- a/CaptchaBot.sln
+++ b/CaptchaBot.sln
@@ -7,6 +7,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CaptchaBot", "CaptchaBot\Ca
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CaptchaBot.Tests", "CaptchaBot.Tests\CaptchaBot.Tests.csproj", "{756DC120-FFDD-4DA3-AB13-6447B0D3A519}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{4B7A8DC8-DB8D-4139-AB22-21DBDA609102}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{023EC92B-AD17-4E5B-90E4-C900DCEE0E8B}"
+ProjectSection(SolutionItems) = preProject
+	.github\workflows\main.yml = .github\workflows\main.yml
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,5 +34,8 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {63003ED9-7A1A-4663-9049-856679A939CF}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{023EC92B-AD17-4E5B-90E4-C900DCEE0E8B} = {4B7A8DC8-DB8D-4139-AB22-21DBDA609102}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This adds a GitHub actions build and test workflow.

Note that I also enabled it to run the build every Saturday, just in case (to more easily watch for any CI degradations, even if there's no active project development). If you don't want it, we may disable the `schedule` trigger.

The build is done on Windows, Linux and macOS, since this is the settings I usually use (and it works well for this project).