### PR TITLE
Add tests for message deletion failure

### DIFF
--- a/CaptchaBot.Tests/WelcomeServiceTests.cs
+++ b/CaptchaBot.Tests/WelcomeServiceTests.cs
@@ -138,6 +138,24 @@ namespace CaptchaBot.Tests
                 _ => {});
         }
 
+        [Fact]
+        public async Task BotShouldNotFailIfMessageCouldNotBeDeleted()
+        {
+            _botMock.Setup(
+                    b => b.DeleteMessageAsync(It.IsAny<ChatId>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("This exception should not fail the message processing."));
+            
+            var config = new AppSettings();
+            var welcomeService = new WelcomeService(config, _usersStore, _logger, _botMock.Object);
+            
+            const int newUserId = 124;
+
+            await ProcessNewChatMember(welcomeService, newUserId, DateTime.UtcNow);
+            await ProcessAnswer(welcomeService, true);
+
+            Assert.Empty(_usersStore.GetAll());
+        }
+
         private async Task DoRemoveJoinTest(
             JoinMessageDeletePolicy policy,
             int joinMessageId,


### PR DESCRIPTION
I have verified that this test was failing before 8b0cee0e5ba89d69ef1eb4a227fb1935e7b47bcf, and now it works well.